### PR TITLE
Allows attaching data to locks.

### DIFF
--- a/examples/lock-example.go
+++ b/examples/lock-example.go
@@ -81,7 +81,7 @@ func main() {
 func start(sess *session.ZKSession, events <-chan session.ZKSessionEvent) {
 	var err error
 
-	gl, err = lock.NewGlobalLock(sess, *lockRoot)
+	gl, err = lock.NewGlobalLock(sess, *lockRoot, "")
 	if err != nil {
 		Log.WithField("error", err).Errorf("Couldn't create lock.")
 		return

--- a/lock/lock.go
+++ b/lock/lock.go
@@ -31,9 +31,10 @@ type GlobalLock struct {
 	Session       *session.ZKSession
 	root          string
 	ephemeralPath string
+	data          string
 }
 
-func NewGlobalLock(session *session.ZKSession, root string) (*GlobalLock, error) {
+func NewGlobalLock(session *session.ZKSession, root string, data string) (*GlobalLock, error) {
 	if stat, _ := session.Exists(root); stat == nil {
 		_, err := session.Create(root, "", 0, zookeeper.WorldACL(zookeeper.PERM_ALL))
 		if err != nil {
@@ -42,7 +43,7 @@ func NewGlobalLock(session *session.ZKSession, root string) (*GlobalLock, error)
 			}
 		}
 	}
-	return &GlobalLock{session, root, ""}, nil
+	return &GlobalLock{session, root, "", data}, nil
 }
 
 func (g *GlobalLock) Destroy() error {
@@ -66,7 +67,7 @@ func (g *GlobalLock) Lock() (err error) {
 	}
 
 	// (1)
-	g.ephemeralPath, err = g.Session.Create(g.root+"/", "", zookeeper.EPHEMERAL|zookeeper.SEQUENCE, zookeeper.WorldACL(zookeeper.PERM_ALL))
+	g.ephemeralPath, err = g.Session.Create(g.root+"/", g.data, zookeeper.EPHEMERAL|zookeeper.SEQUENCE, zookeeper.WorldACL(zookeeper.PERM_ALL))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
@burke and @fw42 

This PR changes the lock interface a little to permit the storing of data on the lock node. When doing `bgpalived` I am looking at ZooKeeper and all I see for locks are the sequenced ephemeral nodes. This isn't very useful. This change permits me to store a small amount of data (i.e. the hostname) on the ephemeral node thus making is easier to know something about one of the sessions competing for the lock.
