### PR TITLE
session: allow optional subscribing to events

### DIFF
--- a/session/session_test.go
+++ b/session/session_test.go
@@ -1,0 +1,57 @@
+package session
+
+import (
+	toxiproxy "github.com/Shopify/toxiproxy/client"
+	"testing"
+	"time"
+)
+
+func TestReceiveEventWhenSubscribing(t *testing.T) {
+	client := toxiproxy.NewClient("http://localhost:8474")
+	proxy := client.NewProxy(&toxiproxy.Proxy{Name: "gozk_test_zookeeper", Listen: "localhost:27445", Upstream: "localhost:2181", Enabled: true})
+
+	err := proxy.Create()
+	if err != nil {
+		t.Error("Failed to create proxy: ", err)
+	}
+	defer proxy.Delete()
+
+	store, err := NewZKSession("localhost:27445", 200*time.Millisecond)
+	if err != nil {
+		t.Error("Failed to connect to Zookeeper: ", err)
+	}
+	defer store.Close()
+
+	events := make(chan ZKSessionEvent)
+	store.Subscribe(events)
+
+	go func() {
+		err := proxy.Delete()
+		if err != nil {
+			t.Error("Failed to delete proxy: ", err)
+		}
+
+		_, _, err = store.Children("/")
+		if err == nil {
+			t.Error("Expected error when listing children")
+		}
+
+		err = proxy.Create()
+		if err != nil {
+			t.Error("Failed to create proxy: ", err)
+		}
+	}()
+
+	select {
+	case event := <-events:
+		if event != SessionDisconnected {
+			t.Error("Expected to receive disconnected: ", event)
+		}
+
+		if <-events != SessionReconnected {
+			t.Error("Expected to receive reconnected: ", event)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Error("Failed to receive event")
+	}
+}


### PR DESCRIPTION
Currently if you don't subscribe to the channel returned you're in for a bad time the second time you lose connectivity, as the `manage()` thread will be blocking waiting for something to read from the channel.

This makes them optional and allows having multiple subscriptions going.

Also adds a Toxiproxy test!

@thegedge @marc-barry 
