### PR TITLE
Fix examples and tests

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -15,6 +15,11 @@ type stdLogger interface {
 	Printf(format string, v ...interface{})
 }
 
+// nullLogger is used when a nil interface is given
+type nullLogger struct{}
+
+func (l *nullLogger) Printf(format string, v ...interface{}) {}
+
 // ErrZKSessionNotConnected is analogous to the SessionFailed event, but returned as an error from NewZKSession on initialization.
 var ErrZKSessionNotConnected = errors.New("unable to connect to ZooKeeper")
 
@@ -54,6 +59,10 @@ func NewZKSession(servers string, recvTimeout time.Duration, logger stdLogger) (
 	conn, events, err := zookeeper.Dial(servers, recvTimeout)
 	if err != nil {
 		return nil, err
+	}
+
+	if logger == nil {
+		logger = &nullLogger{}
 	}
 
 	s := &ZKSession{

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -1,9 +1,10 @@
 package session
 
 import (
-	toxiproxy "github.com/Shopify/toxiproxy/client"
 	"testing"
 	"time"
+
+	toxiproxy "github.com/Shopify/toxiproxy/client"
 )
 
 func TestReceiveEventWhenSubscribing(t *testing.T) {
@@ -16,7 +17,7 @@ func TestReceiveEventWhenSubscribing(t *testing.T) {
 	}
 	defer proxy.Delete()
 
-	store, err := NewZKSession("localhost:27445", 200*time.Millisecond)
+	store, err := NewZKSession("localhost:27445", 200*time.Millisecond, nil)
 	if err != nil {
 		t.Error("Failed to connect to Zookeeper: ", err)
 	}


### PR DESCRIPTION
`NewZKSession` signature changed in #7, so updating the test/example to work with the new signature.

@jpittis @Sirupsen 
