### PR TITLE
Add recursive functions to ZKSession.

### DIFF
--- a/session/recursive.go
+++ b/session/recursive.go
@@ -1,0 +1,101 @@
+package session
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/Shopify/gozk"
+)
+
+var defaultACLs = zookeeper.WorldACL(zookeeper.PERM_ALL)
+
+// ChildrenRecursive returns a slice all of a node's descendents that are at
+// most `maxDepth` levels away from the root.
+func (s *ZKSession) ChildrenRecursive(path string, maxDepth int) ([]string, error) {
+	rootDepth := 0
+	if path != "/" {
+		rootDepth = strings.Count(path, "/")
+	}
+
+	stat, err := s.Exists(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if stat == nil {
+		return []string{}, nil
+	}
+
+	nodes := []string{path}
+	for index := 0; index < len(nodes); index++ {
+		if maxDepth <= 0 || strings.Count(nodes[index], "/") < rootDepth+maxDepth {
+			if children, _, err := s.Children(nodes[index]); err == nil {
+				parent := nodes[index]
+				if parent == "/" {
+					parent = ""
+				}
+
+				for _, child := range children {
+					nodes = append(nodes, parent+"/"+child)
+				}
+			}
+		}
+	}
+	return nodes[1:], nil
+}
+
+// CreateRecursiveAndSet will set data for the given path, creating all parents
+// as necessary.
+func (s *ZKSession) CreateRecursiveAndSet(path string, data string) error {
+	// Since the Set method requires us to create intermediate nodes, we have to
+	// do a little extra work here
+	index := 0
+	for {
+		distanceToNextSlash := strings.Index(path[index+1:], "/")
+		if distanceToNextSlash < 0 {
+			break
+		}
+
+		index += distanceToNextSlash + 1
+		stat, err := s.Exists(path[:index])
+		if err != nil {
+			return err
+		}
+
+		if stat == nil {
+			if _, err := s.Create(path[:index], "", 0, defaultACLs); err != nil {
+				return err
+			}
+		}
+	}
+
+	stat, err := s.Set(path, data, -1)
+	if stat == nil {
+		_, err = s.Create(path, data, 0, defaultACLs)
+	}
+
+	return err
+}
+
+type nodePaths []string
+
+func (s nodePaths) Len() int           { return len(s) }
+func (s nodePaths) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s nodePaths) Less(i, j int) bool { return len(s[i]) < len(s[j]) }
+
+// DeleteRecursive removes a given path and all of its descendents.
+func (s *ZKSession) DeleteRecursive(path string) error {
+	children, err := s.ChildrenRecursive(path, -1)
+	if err != nil {
+		return err
+	}
+
+	sort.Sort(sort.Reverse(nodePaths(children)))
+
+	for _, child := range children {
+		if err := s.Delete(child, -1); err != nil {
+			return err
+		}
+	}
+	return s.Delete(path, -1)
+}

--- a/session/recursive_test.go
+++ b/session/recursive_test.go
@@ -1,0 +1,177 @@
+package session
+
+import (
+	"io/ioutil"
+	"os"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/Shopify/gozk"
+)
+
+func AssertEqual(t *testing.T, expected, actual interface{}) {
+	switch expected.(type) {
+	case []string:
+		sort.Strings(expected.([]string))
+		sort.Strings(actual.([]string))
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected %s, actual %s", expected, actual)
+	}
+}
+
+func AssertNodeValueEqual(t *testing.T, session *ZKSession, path, expected string) {
+	data, _, err := session.Get(path)
+	if err != nil {
+		t.Error("Get error: ", err)
+	}
+	AssertEqual(t, expected, data)
+}
+
+func AssertNodeDoesNotExist(t *testing.T, session *ZKSession, path string) {
+	stat, err := session.Exists(path)
+	if err != nil {
+		t.Error("Exists error: ", err)
+	}
+
+	if stat != nil {
+		t.Error("Expected node to not exist: ", path)
+	}
+}
+
+func AssertNodeExists(t *testing.T, session *ZKSession, path string) {
+	stat, err := session.Exists(path)
+	if err != nil {
+		t.Error("Exists error: ", err)
+	}
+
+	if stat == nil {
+		t.Error("Expected node to exist: ", path)
+	}
+}
+
+func withTestStore(t *testing.T, f func(*ZKSession)) {
+	runDir, err := ioutil.TempDir("", "zk")
+	if err != nil {
+		t.Error("Failed to create zookeeper run dir: ", err)
+	}
+	defer os.RemoveAll(runDir)
+
+	server, err := zookeeper.CreateServer(22447, runDir, "/usr/lib/zookeeper")
+	if err != nil {
+		t.Error("Failed to create zookeeper server: ", err)
+	}
+	defer server.Stop()
+
+	if err := server.Start(); err != nil {
+		t.Error("Failed to start zookeeper server: ", err)
+	}
+
+	store, err := NewZKSession("localhost:22447", 200*time.Millisecond, nil)
+	if err != nil {
+		t.Error("Failed to connect to Zookeeper: ", err)
+	}
+	defer store.Close()
+
+	f(store)
+}
+
+func initializeZK(t *testing.T, s *ZKSession, nodes ...string) {
+	defaultAcls := []zookeeper.ACL{
+		zookeeper.ACL{
+			Perms:  zookeeper.PERM_ALL,
+			Scheme: "world",
+			Id:     "anyone",
+		},
+	}
+
+	for _, node := range nodes {
+		if _, err := s.Create(node, "", 0, defaultAcls); err != nil {
+			t.Error("Unable to create initial value in zk: ", err)
+		}
+	}
+}
+
+func TestChildrenRecursiveWithNonExistingNodeShouldHaveEmptyResult(t *testing.T) {
+	withTestStore(t, func(session *ZKSession) {
+		children, err := session.ChildrenRecursive("/test", -1)
+		if err != nil {
+			t.Error("ChildrenRecursive error: ", err)
+		}
+
+		AssertEqual(t, []string{}, children)
+	})
+}
+
+func TestChildrenRecursiveWithNodesShouldHaveResult(t *testing.T) {
+	withTestStore(t, func(session *ZKSession) {
+		nodes := []string{"/test", "/test/foo", "/test/bar", "/test/bar/eggs"}
+		initializeZK(t, session, nodes...)
+
+		children, err := session.ChildrenRecursive("/test", -1)
+		if err != nil {
+			t.Error("ChildrenRecursive error: ", err)
+		}
+
+		AssertEqual(t, nodes[1:], children)
+	})
+}
+
+func TestChildrenRecursiveWithLimitedDepthShouldReturnSubset(t *testing.T) {
+	withTestStore(t, func(session *ZKSession) {
+		nodes := []string{"/test", "/test/foo", "/test/bar", "/test/bar/eggs", "/test/bar/eggs/spam"}
+		initializeZK(t, session, nodes...)
+
+		children, err := session.ChildrenRecursive("/test", 2)
+		if err != nil {
+			t.Error("ChildrenRecursive error: ", err)
+		}
+
+		AssertEqual(t, []string{"/test/foo", "/test/bar", "/test/bar/eggs"}, children)
+	})
+}
+
+func TestCreateRecursiveAndSetWithNoParentsShouldCreateNodes(t *testing.T) {
+	withTestStore(t, func(session *ZKSession) {
+		if err := session.CreateRecursiveAndSet("/test/foo/bar", "foobar"); err != nil {
+			t.Error("CreateRecursiveAndSet error: ", err)
+		}
+
+		AssertNodeValueEqual(t, session, "/test/foo/bar", "foobar")
+	})
+}
+
+func TestCreateRecursiveAndSetWithParentsShouldNotChangeData(t *testing.T) {
+	withTestStore(t, func(session *ZKSession) {
+		initializeZK(t, session, "/test", "/test/foo")
+
+		if err := session.CreateRecursiveAndSet("/test/foo/bar", "foobar"); err != nil {
+			t.Error("CreateRecursiveAndSet error: ", err)
+		}
+
+		if _, err := session.Set("/test/foo", "spam", 0); err != nil {
+			t.Error("Set error: ", err)
+		}
+
+		AssertNodeValueEqual(t, session, "/test/foo", "spam")
+		AssertNodeValueEqual(t, session, "/test/foo/bar", "foobar")
+	})
+}
+
+func TestDeleteRecursiveShouldDelete(t *testing.T) {
+	withTestStore(t, func(session *ZKSession) {
+		initializeZK(t, session, "/test", "/test/foo", "/test/foo/bar", "/test/foo/bar/spam")
+
+		if err := session.DeleteRecursive("/test/foo"); err != nil {
+			t.Error("DeleteRecursive error: ", err)
+		}
+
+		AssertNodeDoesNotExist(t, session, "/test/foo/bar/spam")
+		AssertNodeDoesNotExist(t, session, "/test/foo/bar")
+		AssertNodeDoesNotExist(t, session, "/test/foo")
+		AssertNodeExists(t, session, "/test")
+	})
+}


### PR DESCRIPTION
Moving some functions from Locutus to gozk-recipes because I'm looking to possibly reuse them in other projects, plus they're fairly useful in general. I did leave a recursive watch function in locutus from now, because it's a big enough beast that it should be dealt with in isolation.

The test is actually an integration test (it starts and tears down a server for each individual test). I went this route because the only other options would be to introduce another interface to mock out the zookeeper client, or faking out the server which would be a huge PITA. The one pain point is that it expects zookeeper to be installed in `/usr/lib/zookeeper`, which it will be when you `sudo apt-get install zookeeper`. I can have the third parameter of `CreateServer` be an empty string, but then it expects `/etc/zookeeper/conf/environment` to exist and have a `CLASSPATH` line in there to determine where to look, which is equally frustrating.

@marc-barry @burke @Sirupsen
