### PR TITLE
Use Shopify's fork of gozk.

### DIFF
--- a/lock/lock.go
+++ b/lock/lock.go
@@ -20,10 +20,10 @@ Here are a few things of note:
 
 import (
 	"fmt"
-	"launchpad.net/gozk"
 	"path"
 	"sort"
 
+	"github.com/Shopify/gozk"
 	"github.com/Shopify/gozk-recipes/session"
 )
 

--- a/session/session.go
+++ b/session/session.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"launchpad.net/gozk"
+	"github.com/Shopify/gozk"
 )
 
 type ZKSessionEvent uint


### PR DESCRIPTION
The Vitess project fixed some panic bugs due to the use of `unsafe.Pointer` for passing in "tags" to the underlying zookeeper library (see youtube/vitess@d18bdd4a0d13985d9ab35d4751e649623e732280). We've now forked this code into [Shopify/gozk](//github.com/Shopify/gozk) and will use this fork indefinitely.

@pushrax @Sirupsen @marc-barry 
