### PR TITLE
add resume ZK sessions

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -59,23 +59,23 @@ type ZKSession struct {
 	log           stdLogger
 }
 
-func ResumeZKSession(servers string, recvTimeout time.Duration, logger stdLogger, clientid *zookeeper.ClientId) (*ZKSession, error) {
-	return newZKSession(servers, recvTimeout, logger, clientid)
+func ResumeZKSession(servers string, recvTimeout time.Duration, logger stdLogger, clientId *zookeeper.ClientId) (*ZKSession, error) {
+	return newZKSession(servers, recvTimeout, logger, clientId)
 }
 
 func NewZKSession(servers string, recvTimeout time.Duration, logger stdLogger) (*ZKSession, error) {
 	return newZKSession(servers, recvTimeout, logger, nil)
 }
 
-func newZKSession(servers string, recvTimeout time.Duration, logger stdLogger, clientid *zookeeper.ClientId) (*ZKSession, error) {
+func newZKSession(servers string, recvTimeout time.Duration, logger stdLogger, clientId *zookeeper.ClientId) (*ZKSession, error) {
 	var conn *zookeeper.Conn
 	var events <-chan zookeeper.Event
 	var err error
 
-	if clientid == nil {
+	if clientId == nil {
 		conn, events, err = zookeeper.Dial(servers, recvTimeout)
 	} else {
-		conn, events, err = zookeeper.Redial(servers, recvTimeout, clientid)
+		conn, events, err = zookeeper.Redial(servers, recvTimeout, clientId)
 	}
 	if err != nil {
 		return nil, err

--- a/session/session.go
+++ b/session/session.go
@@ -59,8 +59,24 @@ type ZKSession struct {
 	log           stdLogger
 }
 
+func ResumeZKSession(servers string, recvTimeout time.Duration, logger stdLogger, clientid *zookeeper.ClientId) (*ZKSession, error) {
+	return newZKSession(servers, recvTimeout, logger, clientid)
+}
+
 func NewZKSession(servers string, recvTimeout time.Duration, logger stdLogger) (*ZKSession, error) {
-	conn, events, err := zookeeper.Dial(servers, recvTimeout)
+	return newZKSession(servers, recvTimeout, logger, nil)
+}
+
+func newZKSession(servers string, recvTimeout time.Duration, logger stdLogger, clientid *zookeeper.ClientId) (*ZKSession, error) {
+	var conn *zookeeper.Conn
+	var events <-chan zookeeper.Event
+	var err error
+
+	if clientid == nil {
+		conn, events, err = zookeeper.Dial(servers, recvTimeout)
+	} else {
+		conn, events, err = zookeeper.Redial(servers, recvTimeout, clientid)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -3,21 +3,19 @@ package session
 import (
 	"testing"
 	"time"
-
 	toxiproxy "github.com/Shopify/toxiproxy/client"
 )
 
 func TestReceiveEventWhenSubscribing(t *testing.T) {
 	client := toxiproxy.NewClient("http://localhost:8474")
-	proxy := client.NewProxy(&toxiproxy.Proxy{Name: "gozk_test_zookeeper", Listen: "localhost:27445", Upstream: "localhost:2181", Enabled: true})
-
-	err := proxy.Create()
+	proxy, err := client.CreateProxy("gozk_test_zookeeper", "localhost:27445", "localhost:2181")
 	if err != nil {
 		t.Fatal("Couldn't create proxy. Is toxiproxy running? Error: ", err)
 	}
-	defer proxy.Delete()
+	defer proxy.Disable()
 
 	store, err := NewZKSession("localhost:27445", 200*time.Millisecond, nil)
+
 	if err != nil {
 		t.Error("Failed to connect to Zookeeper: ", err)
 	}
@@ -27,7 +25,7 @@ func TestReceiveEventWhenSubscribing(t *testing.T) {
 	store.Subscribe(events)
 
 	go func() {
-		err := proxy.Delete()
+		err := proxy.Disable()
 		if err != nil {
 			t.Error("Failed to delete proxy: ", err)
 		}
@@ -37,7 +35,7 @@ func TestReceiveEventWhenSubscribing(t *testing.T) {
 			t.Error("Expected error when listing children")
 		}
 
-		err = proxy.Create()
+		err = proxy.Enable()
 		if err != nil {
 			t.Error("Failed to create proxy: ", err)
 		}
@@ -48,11 +46,17 @@ func TestReceiveEventWhenSubscribing(t *testing.T) {
 		if event != SessionDisconnected {
 			t.Error("Expected to receive disconnected: ", event)
 		}
+	case <-time.After(5 * time.Second):
+		t.Error("Failed to receive event")
+	}
 
-		if <-events != SessionReconnected {
+	select {
+	case event := <-events:
+		if event != SessionReconnected {
 			t.Error("Expected to receive reconnected: ", event)
 		}
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(5 * time.Second):
 		t.Error("Failed to receive event")
 	}
 }
+

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -3,19 +3,25 @@ package session
 import (
 	"testing"
 	"time"
+
+	zookeeper "github.com/Shopify/gozk"
 	toxiproxy "github.com/Shopify/toxiproxy/client"
 )
 
-func TestReceiveEventWhenSubscribing(t *testing.T) {
+func CreateProxy(t *testing.T) (*toxiproxy.Proxy){
 	client := toxiproxy.NewClient("http://localhost:8474")
 	proxy, err := client.CreateProxy("gozk_test_zookeeper", "localhost:27445", "localhost:2181")
 	if err != nil {
 		t.Fatal("Couldn't create proxy. Is toxiproxy running? Error: ", err)
 	}
-	defer proxy.Disable()
+	return proxy
+}
+
+func TestReceiveEventWhenSubscribing(t *testing.T) {
+	proxy := CreateProxy(t)
+	defer proxy.Delete()
 
 	store, err := NewZKSession("localhost:27445", 200*time.Millisecond, nil)
-
 	if err != nil {
 		t.Error("Failed to connect to Zookeeper: ", err)
 	}
@@ -60,3 +66,61 @@ func TestReceiveEventWhenSubscribing(t *testing.T) {
 	}
 }
 
+func TestResumeZKSessionWithValidSession(t *testing.T) {
+	proxy := CreateProxy(t)
+	defer proxy.Delete()
+
+	store, err := NewZKSession("localhost:27445", 200*time.Millisecond, nil)
+	if err != nil {
+		t.Error("Failed to connect to Zookeeper: ", err)
+	}
+
+	events := make(chan ZKSessionEvent)
+	store.Subscribe(events)
+
+	existingClientId, err := store.ClientId().Save()
+	if err != nil {
+		t.Error("Failed to save clientId: ", err)
+	}
+
+	clientId, err := zookeeper.LoadClientId(existingClientId)
+	if err != nil {
+		t.Error("Error loading clientId: ", err)
+	}
+
+	//ResumeZKSession is expected to automatically close any previously existing sessions.
+	resumeStore, err := ResumeZKSession("localhost:27445", 200*time.Millisecond, nil, clientId)
+	if err != nil {
+		t.Error("Failed to resume session with Zookeeper: ", err)
+	}
+	defer resumeStore.Close()
+
+	select {
+	case event := <-events:
+		if event != SessionDisconnected {
+			t.Error("Expected to receive disconnected: ", event)
+		}
+	case <-time.After(5 * time.Second):
+		t.Error("Failed to receive event")
+	}
+}
+
+func TestResumeZKSessionFailsWithInvalidClientId(t *testing.T) {
+	proxy := CreateProxy(t)
+	defer proxy.Delete()
+
+	clientId := make([]byte, 24)
+	for i := 0; i < 24; i++ {
+		clientId[i] = 9
+	}
+
+	invalidClientId, err := zookeeper.LoadClientId(clientId)
+	if err != nil {
+		t.Error("Error loading clientId: ", err)
+	}
+
+	_, err = ResumeZKSession("localhost:27445", 200*time.Millisecond, nil, invalidClientId)
+	if err == nil {
+		t.Error("Resumed session with Zookeeper using incorrect clientId.")
+	}
+}


### PR DESCRIPTION
Adds a function to resume ZK sessions. 
https://github.com/Shopify/magellan/pull/105#issuecomment-270804558

Uses the NewZKSession but passes in a clientId of the session to be resumed and calls `Redial` with this clientId. 

I did some clean up in this PR as well:

I had to clean up the tests to use the new Toxiproxy API. 
CreateProxy() instead of NewProxy() and Create(). 
Disabled() and Enabled() instead of Delete() and Create(). 

In the session tests I refactored the select block so that it would no longer hang forever. Previously it would disconnect but never reconnect.
I changed the 100 miliseconds to 5 seconds to ensure an event would be received and the tests would complete.

I had to run the tests locally 
```
vagrant@vagrant:~/src/go/src/github.com/Shopify/gozk-recipes/session$ go test
PASS
ok  	github.com/Shopify/gozk-recipes/session	3.195s
``` 

- [x] Depends on https://github.com/Shopify/gozk/pull/3 being merged first

@csfrancis @sirupsen @andrewjamesbrown 
@Shopify/webscalenext 