### PR TITLE
change conditional for session not connected to account for connected and connecting states

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -98,7 +98,7 @@ func newZKSession(servers string, recvTimeout time.Duration, logger stdLogger, c
 	var event zookeeper.Event
 	select {
 	case event = <-events:
-		if event.State != zookeeper.STATE_CONNECTED {
+		if event.State == zookeeper.STATE_AUTH_FAILED || event.State == zookeeper.STATE_EXPIRED_SESSION {
 			return nil, ErrZKSessionNotConnected
 		}
 	case <-time.After(5 * time.Second):


### PR DESCRIPTION
I had to revert https://github.com/Shopify/cookbooks/pull/13778 which was updating magellan because there were [errors in bugsnag about not being able to connect to zookeeper](https://app.bugsnag.com/shopify/magellan/errors/581cdb36d51fce042e0a6697?filters[event.since][]=all&filters[device.hostname][]=kafka1.data-chi.shopifydc.com). 

While connected to zookeeper many states are sent as events. In the current version of our code we return an error if the state is not `STATE_CONNECTED`; however, there are two other states `STATE_CONNECTING` and `STATE_ASSOCIATING` that also relate to zookeeper connecting. This is racy. From the logs you can see that the connecting state is sent first and then the connected state.

```
2017-02-13_21:01:57.87482 time="2017-02-13T21:01:57Z" level=info msg="Starting HTTP server" address="127.0.0.1:8439" 
2017-02-13_21:01:57.87487 time="2017-02-13T21:01:57Z" level=info msg="Connecting to Zookeeper" servers=[zk1.ash.shopify.com:2170 zk2.ash.shopify.com:2170 zk3.ash.shopify.com:2170 zk4.ash.shopifydc.com:2170 zk5.ash.shopifydc.com:2170] 
2017-02-13_21:01:58.87915 time="2017-02-13T21:01:58Z" level=warning msg="No existing Zookeeper session was stored" err="Failed to resume zookeeper session with clientId: unable to connect to ZooKeeper" 
2017-02-13_21:01:58.88161 time="2017-02-13T21:01:58Z" level=info msg="New ZK session" clientId=[6 3 164 79 35 139 196 180 102 250 147 157 76 72 136 7 30 56 6 149 177 153 239 207] 
2017-02-13_21:01:58.88162 time="2017-02-13T21:01:58Z" level=info msg="Connected to Zookeeper" servers=[zk1.ash.shopify.com:2170 zk2.ash.shopify.com:2170 zk3.ash.shopify.com:2170 zk4.ash.shopifydc.com:2170 zk5.ash.shopifydc.com:2170] 
2017-02-13_21:02:11.75179 time="2017-02-13T21:02:11Z" level=info msg="Starting HTTP server" address="127.0.0.1:8439" 
2017-02-13_21:02:11.75185 time="2017-02-13T21:02:11Z" level=info msg="Connecting to Zookeeper" servers=[zk1.ash.shopify.com:2170 zk2.ash.shopify.com:2170 zk3.ash.shopify.com:2170 zk4.ash.shopifydc.com:2170 zk5.ash.shopifydc.com:2170] 
2017-02-13_21:02:12.75520 time="2017-02-13T21:02:12Z" level=info msg="Resumed ZK session" clientId=[6 3 164 79 35 139 196 180 102 250 147 157 76 72 136 7 30 56 6 149 177 153 239 207] 
2017-02-13_21:02:12.75522 time="2017-02-13T21:02:12Z" level=info msg="Connected to Zookeeper" servers=[zk1.ash.shopify.com:2170 zk2.ash.shopify.com:2170 zk3.ash.shopify.com:2170 zk4.ash.shopifydc.com:2170 zk5.ash.shopifydc.com:2170] 
```

My vagrant broke so I havent been able to run the gozk-recipe tests. I made the change directly in gozk-recipes and ran the magellan tests and tested magellan on lb-perf1.ash and everything seemed okay. The logs above are from this tophat on lb-perf1.ash. 

@Shopify/webscalenext 