### PR TITLE
Added dev support for an simpler development experience

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,32 @@
+name: gozk-recipes
+
+up:
+  - homebrew:
+    - zookeeper
+  - go: 1.7.5
+  - railgun
+
+env:
+  CGO_CFLAGS: '-I/usr/local/include/zookeeper'
+  CGO_LDFLAGS: '-L/usr/local/lib'
+  TOXIPROXY_HOST: 192.168.64.87
+  TOXIPROXY_URL: http://192.168.64.87:8474
+  ZOOKEEPERS: 192.168.64.87:2181
+
+commands:
+  test: script/test
+
+railgun:
+  image: dev:railgun-common-services-0.2.x
+  services:
+    toxiproxy: 8474
+    zookeeper: 2181
+  ip_address: 192.168.64.87
+  memory: 2G
+  cores: 2
+  disk: 2G
+  hostnames:
+    - gozk-recipes.myshopify.io
+
+packages:
+  - git@github.com:Shopify/dev-shopify.git

--- a/script/test
+++ b/script/test
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+go test -v -p 1 ./...

--- a/test/util.go
+++ b/test/util.go
@@ -1,0 +1,44 @@
+package test
+
+import (
+	"os"
+	"testing"
+
+	toxiproxy "github.com/Shopify/toxiproxy/client"
+)
+
+const PROXY_PORT = "27445"
+
+func CreateProxy(t *testing.T) *toxiproxy.Proxy {
+	url := GetToxiProxyURL(t)
+	zks := GetZooKeepers(t)
+	host := GetToxiProxyHost(t)
+
+	client := toxiproxy.NewClient(url)
+	proxy, err := client.CreateProxy("gozk_test_zookeeper", host+":"+PROXY_PORT, zks)
+	if err != nil {
+		t.Fatal("Couldn't create proxy. Is toxiproxy running? Error: ", err)
+	}
+	return proxy
+}
+
+func GetToxiProxyURL(t *testing.T) string {
+	if os.Getenv("TOXIPROXY_URL") == "" {
+		t.Fatal("TOXIPROXY_URL environment variable must be defined")
+	}
+	return os.Getenv("TOXIPROXY_URL")
+}
+
+func GetToxiProxyHost(t *testing.T) string {
+	if os.Getenv("TOXIPROXY_HOST") == "" {
+		t.Fatal("TOXIPROXY_HOST environment variable must be defined")
+	}
+	return os.Getenv("TOXIPROXY_HOST")
+}
+
+func GetZooKeepers(t *testing.T) string {
+	if os.Getenv("ZOOKEEPERS") == "" {
+		t.Fatal("ZOOKEEPERS environment variable must be defined")
+	}
+	return os.Getenv("ZOOKEEPERS")
+}


### PR DESCRIPTION
@Shopify/traffic, @katdrobnjakovic, @Shopify/webscalenext

I was trying to do some development on this repo and then move onto something for https://github.com/Shopify/magellan and https://github.com/Shopify/bgpalived. But I had a hard time setting up my development environment in order to get the tests to run. This repo has a dependancy on https://github.com/Shopify/toxiproxy (for tests) as well as ZooKeeper itself.

I added `dev` support to make development and testing easier.

With these changes one just has to do the following:
`GOPATH=~ dev up`
```
marc:gozk-recipes marcbarry$ GOPATH=~ dev up
┏━━ Protip ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
┃ ? [Testing] The name of your test must describe the desired outcome. I should be able to read it and figure out what you're testing without reading the implementation.
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
✓ 1/3: Installing Homebrew and packages (nothing to do)
✓ 2/3: Installing Go (nothing to do)
✓ 3/3: Railgun (nothing to do)
```
`GOPATH=~ dev test`
```
marc:gozk-recipes marcbarry$ GOPATH=~ dev test
=== RUN   TestCreateAndMaintain
waiting 10.5 seconds for zookeeper to purge an ephemeral node...
re-establishing proxy
waiting 20 seconds for maintainEphemeral to time out waiting for connection re-establishment
--- PASS: TestCreateAndMaintain (31.03s)
PASS
ok  	github.com/Shopify/gozk-recipes/ephemeral	31.041s
?   	github.com/Shopify/gozk-recipes/examples	[no test files]
?   	github.com/Shopify/gozk-recipes/lock	[no test files]
=== RUN   TestChildrenRecursiveWithNonExistingNodeShouldHaveEmptyResult
--- PASS: TestChildrenRecursiveWithNonExistingNodeShouldHaveEmptyResult (0.01s)
=== RUN   TestChildrenRecursiveWithNodesShouldHaveResult
--- PASS: TestChildrenRecursiveWithNodesShouldHaveResult (0.01s)
=== RUN   TestChildrenRecursiveWithLimitedDepthShouldReturnSubset
--- PASS: TestChildrenRecursiveWithLimitedDepthShouldReturnSubset (0.01s)
=== RUN   TestCreateRecursiveAndSetWithNoParentsShouldCreateNodes
--- PASS: TestCreateRecursiveAndSetWithNoParentsShouldCreateNodes (0.01s)
=== RUN   TestCreateRecursiveAndSetWithParentsShouldNotChangeData
--- PASS: TestCreateRecursiveAndSetWithParentsShouldNotChangeData (0.01s)
=== RUN   TestDeleteRecursiveShouldDelete
--- PASS: TestDeleteRecursiveShouldDelete (0.01s)
=== RUN   TestReceiveEventWhenSubscribing
--- PASS: TestReceiveEventWhenSubscribing (1.34s)
=== RUN   TestResumeZKSessionWithValidSession
--- PASS: TestResumeZKSessionWithValidSession (0.01s)
=== RUN   TestResumeZKSessionFailsWithInvalidClientId
--- PASS: TestResumeZKSessionFailsWithInvalidClientId (0.00s)
=== RUN   TestResumeZKSessionWithInvalidClientIdDoesNotDisconnectExistingSession
--- PASS: TestResumeZKSessionWithInvalidClientIdDoesNotDisconnectExistingSession (0.00s)
	session_test.go:151: Existing session was not disconnected by ResumeZKSession with invalid clientId
PASS
ok  	github.com/Shopify/gozk-recipes/session	1.427s
?   	github.com/Shopify/gozk-recipes/test	[no test files]
```