### PR TITLE
close the connection if it's there already

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -106,21 +106,21 @@ func newZKSession(servers string, recvTimeout time.Duration, logger stdLogger, c
 }
 
 func waitForConnection(events <-chan zookeeper.Event) error {
-  for {
-    select {
-    case event := <-events:
-      switch event.State {
-        case zookeeper.STATE_AUTH_FAILED, zookeeper.STATE_EXPIRED_SESSION, zookeeper.STATE_CLOSED:
-          return ErrZKSessionNotConnected
-        case zookeeper.STATE_CONNECTED:
-          return nil
-      }
-    case <-time.After(5 * time.Second):
-      return ErrZKSessionNotConnected
-    }
-  }
-  // We should not reach this state
-  return ErrZKSessionNotConnected
+	for {
+		select {
+		case event := <-events:
+			switch event.State {
+			case zookeeper.STATE_AUTH_FAILED, zookeeper.STATE_EXPIRED_SESSION, zookeeper.STATE_CLOSED:
+				return ErrZKSessionNotConnected
+			case zookeeper.STATE_CONNECTED:
+				return nil
+			}
+		case <-time.After(5 * time.Second):
+			return ErrZKSessionNotConnected
+		}
+	}
+	// We should not reach this state
+	return ErrZKSessionNotConnected
 }
 
 func (s *ZKSession) Subscribe(subscription chan<- ZKSessionEvent) {
@@ -148,6 +148,12 @@ func (s *ZKSession) manage() {
 				conn, events, err := zookeeper.Redial(s.servers, s.recvTimeout, s.clientID)
 				if err == nil {
 					s.mu.Lock()
+					if s.conn != nil {
+						err := zookeeper.Close()
+						if err != nil {
+							s.log.Printf("error in closing existing zookeeper connection: %v", err)
+						}
+					}
 					s.conn = conn
 					s.events = events
 					s.clientID = conn.ClientId()

--- a/session/session.go
+++ b/session/session.go
@@ -149,7 +149,7 @@ func (s *ZKSession) manage() {
 				if err == nil {
 					s.mu.Lock()
 					if s.conn != nil {
-						err := zookeeper.Close()
+						err := s.conn.Close()
 						if err != nil {
 							s.log.Printf("error in closing existing zookeeper connection: %v", err)
 						}


### PR DESCRIPTION
# wat
fix a leaking connection in the session expired state.

# how
close it

# why
If this condition hits, we call redial, redial ends up calling dial which calls zookeeper_init(), which ends up allocating a pipe for the self pipe trick. We then lose the old reference to the connection, and the GC won't cleanup c resources afaik.  We noticed many of these pipes open on hosts that are failing to connect to zookeeper.  

Not sure how to test this, but I believe this is enough.  I guess I could incur a deadlock is the only problem, I could move the close to outside of the mutex lock?

other function change is because I auto run gofmt.

@insom @fw42 @xldenis 