### PR TITLE
log when expired session conn is reset

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -144,9 +144,11 @@ func (s *ZKSession) manage() {
 		case event := <-s.events:
 			switch event.State {
 			case zookeeper.STATE_EXPIRED_SESSION:
+				s.log.Printf("gozk-recipes/session: got STATE_EXPIRED_SESSION for conn %+v", s.conn)
 				expired = true
 				conn, events, err := zookeeper.Redial(s.servers, s.recvTimeout, s.clientID)
 				if err == nil {
+					s.log.Printf("gozk-recipes/session: STATE_EXPIRED_SESSION redialed conn %+v", conn)
 					s.mu.Lock()
 					if s.conn != nil {
 						err := s.conn.Close()


### PR DESCRIPTION
I'd like us to log connection state when an expired session event is encountered.

For two reasons:

1. We can see how often and when the connection is being reset.

2. We can confirm the connection is being reset properly. For example by looking at the struct pointers we can confirm they're different structs.

@marc-barry @sirupsen