### PR TITLE
Fix dev and a logging message.

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -3,7 +3,7 @@ name: gozk-recipes
 up:
   - homebrew:
     - zookeeper
-  - go: 1.7.5
+  - go: 1.9.2
   - railgun
 
 env:
@@ -15,18 +15,6 @@ env:
 
 commands:
   test: script/test
-
-railgun:
-  image: dev:railgun-common-services-0.2.x
-  services:
-    toxiproxy: 8474
-    zookeeper: 2181
-  ip_address: 192.168.64.87
-  memory: 2G
-  cores: 2
-  disk: 2G
-  hostnames:
-    - gozk-recipes.myshopify.io
 
 packages:
   - git@github.com:Shopify/dev-shopify.git

--- a/examples/lock-example.go
+++ b/examples/lock-example.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Shopify/gozk-recipes/lock"
 	"github.com/Shopify/gozk-recipes/session"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 const (

--- a/railgun.yml
+++ b/railgun.yml
@@ -1,0 +1,18 @@
+# https://dev-accel.shopify.io/dev/railgun/Railgun-Config
+name: gozk-recipes
+
+vm:
+  image:      /opt/dev/misc/railgun-images/default
+  ip_address: 192.168.64.87
+  memory: 2G
+  cores: 2
+
+volumes:
+  root:  '2G'
+
+services:
+  - toxiproxy
+  - zookeeper
+
+hostnames:
+  - gozk-recipes.myshopify.io

--- a/railgun.yml
+++ b/railgun.yml
@@ -4,11 +4,11 @@ name: gozk-recipes
 vm:
   image:      /opt/dev/misc/railgun-images/default
   ip_address: 192.168.64.87
-  memory: 2G
+  memory: 200M
   cores: 2
 
 volumes:
-  root:  '2G'
+  root:  '100M'
 
 services:
   - toxiproxy

--- a/session/session.go
+++ b/session/session.go
@@ -153,7 +153,7 @@ func (s *ZKSession) manage() {
 					if s.conn != nil {
 						err := s.conn.Close()
 						if err != nil {
-							s.log.Printf("error in closing existing zookeeper connection: %v", err)
+							s.log.Printf("gozk-recipes/session: error in closing existing zookeeper connection: %v", err)
 						}
 					}
 					s.conn = conn


### PR DESCRIPTION
@Shopify/edgescale 

This pull request does a few things:
 - Update Go
 - Create a `railgun.yml` file (see https://engineering.shopify.io/tools/dev/railgun/Railgun-Config)
 - Adjust a logging message which was missing `gozk-recipes/session`

```
marc:gozk-recipes marcbarry$ dev up
⭑ 1/4 Prerequisites
⭑ 2/4 Homebrew Packages
⭑ 3/4 Golang
┏━━ 👩‍💻  4/4 Railgun ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
┃ ⭑ install railgun 2.3.2
┃ ⭑ add project to Railgun.app
┃ ⭑ download railgun image (railgun-os-stage2-0.1.10.sfs)
┃ 𝒾 start railgun
┃ ✓ (docker)
┃ ✓ (openssh)
┃ ✓ toxiproxy
┃ ✓ zookeeper
┃ ✓ start railgun: done
┃ ⭑ add hosts to /etc/hosts
┃ ⭑ launch railgun app
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ (8.93s) ━━
```
```
marc:gozk-recipes marcbarry$ dev test
👩‍💻  Running script/test from dev.yml
=== RUN   TestCreateAndMaintain
waiting 10.5 seconds for zookeeper to purge an ephemeral node...
re-establishing proxy
waiting 20 seconds for maintainEphemeral to time out waiting for connection re-establishment
--- PASS: TestCreateAndMaintain (31.06s)
PASS
ok  	github.com/Shopify/gozk-recipes/ephemeral	31.074s
?   	github.com/Shopify/gozk-recipes/examples	[no test files]
?   	github.com/Shopify/gozk-recipes/lock	[no test files]
=== RUN   TestChildrenRecursiveWithNonExistingNodeShouldHaveEmptyResult
--- PASS: TestChildrenRecursiveWithNonExistingNodeShouldHaveEmptyResult (0.01s)
=== RUN   TestChildrenRecursiveWithNodesShouldHaveResult
--- PASS: TestChildrenRecursiveWithNodesShouldHaveResult (0.02s)
=== RUN   TestChildrenRecursiveWithLimitedDepthShouldReturnSubset
--- PASS: TestChildrenRecursiveWithLimitedDepthShouldReturnSubset (0.01s)
=== RUN   TestCreateRecursiveAndSetWithNoParentsShouldCreateNodes
--- PASS: TestCreateRecursiveAndSetWithNoParentsShouldCreateNodes (0.02s)
=== RUN   TestCreateRecursiveAndSetWithParentsShouldNotChangeData
--- PASS: TestCreateRecursiveAndSetWithParentsShouldNotChangeData (0.02s)
=== RUN   TestDeleteRecursiveShouldDelete
--- PASS: TestDeleteRecursiveShouldDelete (0.01s)
=== RUN   TestReceiveEventWhenSubscribing
--- PASS: TestReceiveEventWhenSubscribing (1.34s)
=== RUN   TestResumeZKSessionWithValidSession
--- PASS: TestResumeZKSessionWithValidSession (0.01s)
=== RUN   TestResumeZKSessionFailsWithInvalidClientId
--- PASS: TestResumeZKSessionFailsWithInvalidClientId (0.00s)
=== RUN   TestResumeZKSessionWithInvalidClientIdDoesNotDisconnectExistingSession
--- PASS: TestResumeZKSessionWithInvalidClientIdDoesNotDisconnectExistingSession (0.00s)
	session_test.go:151: Existing session was not disconnected by ResumeZKSession with invalid clientId
PASS
ok  	github.com/Shopify/gozk-recipes/session	1.462s
?   	github.com/Shopify/gozk-recipes/test	[no test files]
```