### PR TITLE
Just reference Go 1.9 to always pick up the latest minor version

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -3,7 +3,8 @@ name: gozk-recipes
 up:
   - homebrew:
     - zookeeper
-  - go: 1.9.2
+  - go:
+      version: 1.9
   - railgun
 
 env:


### PR DESCRIPTION
@Shopify/edgescale

Belongs with #19. This is better than specifically referencing the minor version.