### PR TITLE
Revert "Just reference Go 1.9 to always pick up the latest minor version"

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -3,8 +3,7 @@ name: gozk-recipes
 up:
   - homebrew:
     - zookeeper
-  - go:
-      version: 1.9
+  - go: 1.9.2
   - railgun
 
 env:


### PR DESCRIPTION
Reverts Shopify/gozk-recipes#20

I was completely wrong about this. It actually downgraded to `1.9`.