### PR TITLE
close conn if an error is encountered

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -97,6 +97,7 @@ func newZKSession(servers string, recvTimeout time.Duration, logger stdLogger, c
 
 	err = waitForConnection(events)
 	if err != nil {
+		_ = s.conn.Close()
 		return nil, err
 	}
 


### PR DESCRIPTION
This is fixing a fd leak bug that we've found in Magellan.

You can find how I located the bug in [this issue comment](https://github.com/Shopify/magellan/issues/152#issuecomment-351085823). I believe that issue provides proper explanation. In summary:

1. We create a zk connection.

2. If there's an error, we return early without ever closing it.

3. This causes thread and pipe leaks that are created but never cleaned in the underlying C library.

@alanctgardner @marc-barry @sirupsen